### PR TITLE
Misc updates

### DIFF
--- a/Get-GistAuthHeader.ps1
+++ b/Get-GistAuthHeader.ps1
@@ -1,12 +1,12 @@
 function Get-GistAuthHeader {
 
-    if(!$Global:cred) { $Global:cred = Get-Credential ''}
+    if(!$Global:GitHubCred) { $Global:GitHubCred = Get-Credential ''}
 
-    $authInfo = "{0}:{1}" -f $Global:cred.UserName, $Global:cred.GetNetworkCredential().Password
+    $authInfo = "{0}:{1}" -f $Global:GitHubCred.UserName, $Global:GitHubCred.GetNetworkCredential().Password
     $authInfo = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($authInfo))
 
     @{
-        "Authorization" = "Basic " + $authInfo
-        "Content-Type" = "application/json"
+        'Authorization' = 'Basic ' + $authInfo
+        'Content-Type' = 'application/json'
     }
 }

--- a/Get-GistContent.ps1
+++ b/Get-GistContent.ps1
@@ -1,9 +1,25 @@
 function Get-GistContent {
     param(
     	[Parameter(ValueFromPipelineByPropertyName)]
-    	[string]$RawUrl
+    	[string]$RawUrl,
+
+        [Parameter()]
+        [switch]$SendToISE
     )
     
     Begin   { $Header = Get-GistAuthHeader }
-    Process { Invoke-RestMethod -Uri $RawUrl -Headers $Header }
+
+    Process {
+        $gistContent = Invoke-RestMethod -Uri $RawUrl -Headers $Header
+
+        if($SendToISE) {
+            $newISETab = $psISE.CurrentPowerShellTab.Files.Add()
+            $newISETab.Editor.Text = $gistContent
+            $newISETab.Editor.SetCaretPosition(1,1)
+        }
+
+        else {
+            Write-Output $gistContent
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -3,16 +3,15 @@ Posh-Gist
 Share your PowerShell scripts easily with [GitHub Gists](https://gist.github.com/) and Send-Gist.
 
 After doing an `Import-Module Gist` ***Ctrl+Shift+S*** is wired up in PowerShell ISE. Load up a script or write one from scratch, press the shortcut keys and you've created a gist.
+**NOTE** If a selection is made, only the selection will be used for the new gist.
 
 ![Image](https://raw.github.com/dfinke/Posh-Gist/master/UsingPoshGist.gif)
-
-***Note***: This version does not support updating an existing gist  
 
 You need a [GitHub](https://github.com/join) account to post a gist, this does not support anonymous posts.   
 
 ToDo
 -
-* **[DONE 12/11/13]** Add Updating an existing gist
+* ~~Add Updating an existing gist~~
 * Add Deleting an existing gist
 * Expand capabilities to send files on disk
-* Load an existing gist into ISE
+* ~~Load an existing gist into ISE~~

--- a/Send-Gist.ps1
+++ b/Send-Gist.ps1
@@ -1,32 +1,39 @@
 function Send-Gist {
 
     $fileName = Split-Path -Leaf $psISE.CurrentFile.FullPath
-    $contents = $psISE.CurrentFile.Editor.Text
+
+    if($psISE.CurrentFile.Editor.SelectedText) {
+        $contents = $psISE.CurrentFile.Editor.SelectedText
+    }
+
+    else {
+        $contents = $psISE.CurrentFile.Editor.Text
+    }
 
     $gist = @{
-      "description"="Description for $($fileName)"
-      "public"= $true
-      "files"= @{
+      'description'="Description for $($fileName)"
+      'public'= $true
+      'files'= @{
         "$($fileName)"= @{
-          "content"= "$($contents)"
+          'content'= "$($contents)"
         }
       }
     }
 
     $Header = Get-GistAuthHeader 
  
-    $BaseUri = $Uri = "https://api.github.com/gists"    
+    $BaseUri = $Uri = 'https://api.github.com/gists'    
     $Method  = 'POST'
  
     $targetGist = Get-Gist $Global:cred.UserName $fileName
     if($targetGist) {
  
-        $r=[System.Windows.MessageBox]::Show("Gist already exists. Do you want to overwrite?", "Confirmation", "YesNo", "Question")
+        $r=[System.Windows.MessageBox]::Show('Gist already exists. Do you want to overwrite?', 'Confirmation', 'YesNo', 'Question')
         
-        if($r -eq "no") {return}
+        if($r -eq 'no') {return}
 
         $Uri = $BaseUri + "/$($targetGist.GistID)" 
-        $Method = "Patch"
+        $Method = 'Patch'
     }
 
     $resp = Invoke-RestMethod -Uri $Uri -Method $Method -Headers $Header -Body ($gist | ConvertTo-Json)


### PR DESCRIPTION
- Renamed global variable to GitHubCred to minimize risk of interfering
  with existing global credential object
- Updated Get-GistContent with a new parameter to send the Gist to a new
  ISE tab
- Updated Send-Gist so that if text is selected, only the selected text
  will be created as a new Gist. Otherwise the whole file will be used
- Updated README.md
