### PR TITLE
Fixed instruction step on how to import

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ Posh-Gist
 =
 Share your PowerShell scripts easily with [GitHub Gists](https://gist.github.com/) and Send-Gist.
 
-After doing an `Import-Module Gist` ***Ctrl+Shift+S*** is wired up in PowerShell ISE. Load up a script or write one from scratch, press the shortcut keys and you've created a gist.
+After doing an `Import-Module PoshGist` ***Ctrl+Shift+S*** is wired up in PowerShell ISE. Load up a script or write one from scratch, press the shortcut keys and you've created a gist.
 **NOTE.** If a selection is made, only the selection will be used for the new gist.
 
 ![Image](https://raw.github.com/dfinke/Posh-Gist/master/UsingPoshGist.gif)
 
-You need a [GitHub](https://github.com/join) account to post a gist, this does not support anonymous posts.   
+You need a [GitHub](https://github.com/join) account to post a gist, this does not support anonymous posts.
 
 ToDo
 -


### PR DESCRIPTION
'Import-Module Gist' does not work since the module file is named ``PoshGist.psm1``.
I updated the step to ``Import-Module PoshGist``